### PR TITLE
Line and circle drawing primitives

### DIFF
--- a/include/dr4/texture.hpp
+++ b/include/dr4/texture.hpp
@@ -28,6 +28,16 @@ struct Line {
 
 };
 
+struct Circle {
+
+    Vec2f center;
+    float radius;
+    Color fill;
+    float borderThickness = 0;
+    Color borderColor = Color(255, 0, 0, 255);
+
+};
+
 class Font {
 
   public:
@@ -83,8 +93,9 @@ public:
 
     virtual void Clear(dr4::Color color) = 0;
 
-    virtual void Draw(const Rectangle &rect) = 0;
-    virtual void Draw(const Line      &line) = 0;
+    virtual void Draw(const Rectangle &rect)   = 0;
+    virtual void Draw(const Circle    &circle) = 0;
+    virtual void Draw(const Line      &line)   = 0;
 
     virtual void Draw(const Text &text) = 0;
 


### PR DESCRIPTION
Add `Line` and `Circle` in `texture.hpp`, with their corresponding `void Texture::Draw(...)` methods.
Reasoning: `Line` is useful for drawing line segments, like underlines or other simple primitives, and `Circle` may be used as a small dot, for constructing simple shapes.