### PR TITLE
Monotonic time

### DIFF
--- a/include/dr4/window.hpp
+++ b/include/dr4/window.hpp
@@ -31,6 +31,9 @@ public:
     virtual void Draw(const Texture &texture, const Vec2f &pos) = 0;
     virtual void Display() = 0;
 
+    // Monotonic time
+    virtual double GetTime() = 0;
+
     virtual Texture   *CreateTexture()   = 0;
     virtual Image     *CreateImage()     = 0;
     virtual Font      *CreateFont()      = 0;


### PR DESCRIPTION
Функция `double Window::GetTime()` удивительно, что ещё не появилась в коде, потому что `IdleEvent` уже использует `double absTime`, а значит нужен формальный способ получения времени для формирования такий событий.