### PR TITLE
Fix dr4backend inheritance

### DIFF
--- a/include/misc/dr4_ifc.hpp
+++ b/include/misc/dr4_ifc.hpp
@@ -11,7 +11,7 @@ namespace dr4 {
  *
  * To be rewritten later to use appropriate plugin system.
  */
-class DR4Backend : cum::Plugin {
+class DR4Backend : public cum::Plugin {
 
 public:
 
@@ -19,7 +19,6 @@ public:
     inline virtual ~DR4Backend() {};
 
 };
-
 
 /**
  * @brief Name of a function all DR4 backend plugins must export


### PR DESCRIPTION
Бэкэнд графической библиотеки у нас являлся плагином, однако не наследовался от него, что странно. Поэтому я добавил наследование и убрал дублирующийся метод Name(), так как в плагине уже был метод GetName()